### PR TITLE
fix: Ensure node api routes receive the rewritten path & search

### DIFF
--- a/packages/next/server/next-server.ts
+++ b/packages/next/server/next-server.ts
@@ -117,6 +117,13 @@ type ExpressMiddleware = (
   next: (err?: Error) => void
 ) => void
 
+type ConstructURLProps = {
+  req: BaseNextRequest | NodeNextRequest
+  query: ParsedUrlQuery
+  params?: Params | undefined
+  pathname: string
+}
+
 export interface NodeRequestHandler {
   (
     req: IncomingMessage | BaseNextRequest,
@@ -788,8 +795,16 @@ export default class NextNodeServer extends BaseServer {
       }
     }
 
+    const r = (req as NodeNextRequest).originalRequest
+    const url = new URL(
+      this.constructURL({ req, query, params, pathname: page })
+    )
+
+    // request.url consists of path + search in this context
+    r.url = url.pathname + url.search
+
     await apiResolver(
-      (req as NodeNextRequest).originalRequest,
+      r,
       (res as NodeNextResponse).originalResponse,
       query,
       pageModule,
@@ -823,13 +838,19 @@ export default class NextNodeServer extends BaseServer {
     renderOpts.serverComponentManifest = this.serverComponentManifest
     renderOpts.serverCSSManifest = this.serverCSSManifest
 
+    const r = (req as NodeNextRequest).originalRequest
+    const url = new URL(this.constructURL({ req, query, pathname }))
+
+    // request.url consists of path + search in this context
+    r.url = url.pathname + url.search
+
     if (
       this.nextConfig.experimental.appDir &&
       (renderOpts.isAppPath || query.__flight__)
     ) {
       const isPagesDir = !renderOpts.isAppPath
       return appRenderToHTMLOrFlight(
-        req.originalRequest,
+        r,
         res.originalResponse,
         pathname,
         query,
@@ -838,13 +859,7 @@ export default class NextNodeServer extends BaseServer {
       )
     }
 
-    return renderToHTML(
-      req.originalRequest,
-      res.originalResponse,
-      pathname,
-      query,
-      renderOpts
-    )
+    return renderToHTML(r, res.originalResponse, pathname, query, renderOpts)
   }
 
   protected streamResponseChunk(res: NodeNextResponse, chunk: any) {
@@ -1706,6 +1721,9 @@ export default class NextNodeServer extends BaseServer {
     const normalizedPathname = removeTrailingSlash(params.parsed.pathname || '')
 
     // For middleware to "fetch" we must always provide an absolute URL
+
+    // TODO check if we can call constructURL() here as well to DRY this up
+
     const query = urlQueryToSearchParams(params.parsed.query).toString()
     const locale = params.parsed.query.__nextLocale
 
@@ -2047,31 +2065,15 @@ export default class NextNodeServer extends BaseServer {
     }
 
     // For middleware to "fetch" we must always provide an absolute URL
-    const locale = query.__nextLocale
-    const isDataReq = !!query.__nextDataReq
-    const queryString = urlQueryToSearchParams(query).toString()
 
-    if (isDataReq) {
-      params.req.headers['x-nextjs-data'] = '1'
-    }
+    const urlString = this.constructURL({
+      req: params.req,
+      query,
+      params: params.params,
+      pathname: page,
+    })
 
-    let normalizedPathname = normalizeAppPath(page)
-    if (isDynamicRoute(normalizedPathname)) {
-      const routeRegex = getNamedRouteRegex(normalizedPathname)
-      normalizedPathname = interpolateDynamicPath(
-        normalizedPathname,
-        Object.assign({}, params.params, query),
-        routeRegex
-      )
-    }
-
-    const url = `${getRequestMeta(params.req, '_protocol')}://${
-      this.hostname
-    }:${this.port}${locale ? `/${locale}` : ''}${normalizedPathname}${
-      queryString ? `?${queryString}` : ''
-    }`
-
-    if (!url.startsWith('http')) {
+    if (!urlString.startsWith('http')) {
       throw new Error(
         'To use middleware you must provide a `hostname` and `port` to the Next.js Server'
       )
@@ -2091,7 +2093,7 @@ export default class NextNodeServer extends BaseServer {
           i18n: this.nextConfig.i18n,
           trailingSlash: this.nextConfig.trailingSlash,
         },
-        url,
+        url: urlString,
         page: {
           name: params.page,
           ...(params.params && { params: params.params }),
@@ -2130,5 +2132,33 @@ export default class NextNodeServer extends BaseServer {
       this.distDir,
       this._isLikeServerless ? SERVERLESS_DIRECTORY : SERVER_DIRECTORY
     )
+  }
+
+  protected constructURL({ req, query, params, pathname }: ConstructURLProps) {
+    const locale = query.__nextLocale
+    const isDataReq = !!query.__nextDataReq
+    const queryString = urlQueryToSearchParams(query).toString()
+
+    if (isDataReq) {
+      req.headers['x-nextjs-data'] = '1'
+    }
+
+    let normalizedPathname = normalizeAppPath(pathname)
+    if (isDynamicRoute(normalizedPathname)) {
+      const routeRegex = getNamedRouteRegex(normalizedPathname)
+      normalizedPathname = interpolateDynamicPath(
+        normalizedPathname,
+        Object.assign({}, params, query),
+        routeRegex
+      )
+    }
+
+    const url = `${getRequestMeta(req, '_protocol')}://${this.hostname}:${
+      this.port
+    }${locale ? `/${locale}` : ''}${normalizedPathname}${
+      queryString ? `?${queryString}` : ''
+    }`
+
+    return url
   }
 }


### PR DESCRIPTION
## Bug

- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`

## Description

We noticed that the `request.url` is being [reconstructed](https://github.com/vercel/next.js/blob/canary/packages/next/server/next-server.ts#L2068) on edge functions on local dev environment.

When a middleware performs a rewrite, potentially changing the path and adding query params, the reconstructed URL points to the _rewritten_ URL and includes the final query string (for edge on dev).

For node & pages on dev, the original request is passed along instead, so the route is not aware of the rewrite or new query params. The `query` object is updated, but the `req.url` is not.

As a recap of middleware rewrite behavior:

Edge route handlers:
- request.url points to rewritten URL on dev
- request.url points to original URL on prod

Node route handlers:
- request.url points to original URL on dev
- request.url points to original URL on prod

It would be ideal if the behavior across route types and environments could be aligned.
It appears that reverse proxies such as nginx propagate the final request to a route, which may suggest this is the way to go.

We are currently building our new authentication middleware solution for Next.js >= 12.2 and we need to pass the auth state from middleware to API routes using the query string.

Therefore we tried moving the URL (re)construction logic to a common utility function and call it in:

* runEdgeFunction
* runApi (node API route case)
* renderHTML (for pages)

Instead of passing the `req.originalRequest` as is, we modify the request url and pass the modified request.

This results in the rewritten path & query being available in the `req.url` in routes.

Opening current PR for guidance on whether this is a move in the right direction.

## Notes

- We would probably want to hang onto the original request URL in a custom header
- Ideally we'd like to clone the original request instead of changing its url in-place
- We are currently working on testing. We opened the PR in order to bring this to your attention faster as we will keep adding tests.

## Related issues

Fixes https://github.com/vercel/next.js/issues/40651
